### PR TITLE
ci: allow all scopes on PR titles (drop release disallow)

### DIFF
--- a/.github/workflows/pr-title-conventional-commits.yml
+++ b/.github/workflows/pr-title-conventional-commits.yml
@@ -23,8 +23,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          disallowScopes: |
-            release
           wip: true
 
       - uses: marocchino/sticky-pull-request-comment@v3.0.4


### PR DESCRIPTION
## Summary
\`amannn/action-semantic-pull-request\` already had \`requireScope\` defaulting to \`false\`, so scopes were optional today — but \`release\` was on the disallow-list, which rejected anything like \`ci(release): ...\`.

This PR drops \`disallowScopes\` entirely so the policy is "any scope is allowed, none is required." Behavior:

| Title | Before | After |
|-------|--------|-------|
| \`feat: add thing\` | ✅ | ✅ |
| \`fix(api): do thing\` | ✅ | ✅ |
| \`ci(release): tweak workflow\` | ❌ disallowed scope | ✅ |
| \`feat\` (no colon) | ❌ | ❌ (still invalid by spec) |
| \`WIP: ...\` | ✅ (\`wip: true\`) | ✅ |

A comment notes how to re-introduce a block-list later if a specific scope ever needs to be banned again.

## Test plan
- [ ] After merge, open a test PR titled \`ci(release): noop\` somewhere consuming this workflow and verify it passes the title check
- [ ] Open one titled \`some random title\` and verify it still fails (CC type/format still enforced)